### PR TITLE
Drop PHP 7.3 support

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,14 +16,14 @@ branches:
         contexts:
           - "Coding Standards (7.4)"
           - "Static Code Analysis (7.4)"
-          - "Test (PHP 7.3, symfony 4.4, lowest)"
-          - "Test (PHP 7.3, symfony 5.1, lowest)"
-          - "Test (PHP 7.3, symfony 4.4, highest)"
-          - "Test (PHP 7.3, symfony 5.1, highest)"
           - "Test (PHP 7.4, symfony 4.4, lowest)"
           - "Test (PHP 7.4, symfony 5.1, lowest)"
           - "Test (PHP 7.4, symfony 4.4, highest)"
           - "Test (PHP 7.4, symfony 5.1, highest)"
+          - "Test (PHP 8, symfony 4.4, lowest)"
+          - "Test (PHP 8, symfony 5.1, lowest)"
+          - "Test (PHP 8, symfony 4.4, highest)"
+          - "Test (PHP 8, symfony 5.1, highest)"
           - "Code Coverage (7.4)"
           - "Mutation Tests (7.4)"
         strict: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,7 +111,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.3
           - 7.4
           - 8.0
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "doctrine/common": "^2.12 || ^3.0",
         "doctrine/dbal": "^2.6",
         "doctrine/event-manager": "^1.0",

--- a/vendor-bin/tools/composer.json
+++ b/vendor-bin/tools/composer.json
@@ -23,7 +23,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.3"
+            "php": "7.4"
         }
     }
 }


### PR DESCRIPTION
Security support will end in a few months: https://www.php.net/supported-versions.php